### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 22 * * *'
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   run_script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/qiita-trending-to-bluesky/security/code-scanning/2](https://github.com/aegisfleet/qiita-trending-to-bluesky/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations:
- `contents: read` is required for checking out the repository.
- `actions: read` is required for downloading and uploading artifacts.
- No other permissions appear necessary.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `run_script` job. Adding it at the root level is more concise and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
